### PR TITLE
l10n: Correct spelling of "WebAuthn"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>twofactor_webauthn</id>
-	<name>Two-Factor Webauthn</name>
-	<summary>Webauthn two-factor provider</summary>
-	<description>A two-factor provider for webauthn devices</description>
+	<name>Two-Factor WebAuthn</name>
+	<summary>WebAuthn two-factor provider</summary>
+	<description>A two-factor provider for WebAuthn devices</description>
 	<version>0.2.15</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -41,7 +41,7 @@
 		</p>
 		<p v-if="notSupported" class="webauthn-warning">
 			<span class="icon icon-info" />
-			{{ t('twofactor_webauthn', 'Your browser does not support Webauthn.') }}
+			{{ t('twofactor_webauthn', 'Your browser does not support WebAuthn.') }}
 		</p>
 		<p v-if="httpWarning" class="webauthn-warning">
 			<span class="icon icon-info" />


### PR DESCRIPTION
The change is also changing the name of the application. In my opinion it should be called "Two-Factor WebAuthn".

@ChristophWurst also in About on GitHub, the description should be changed:
Webauthn Twofactor Provider for Nextcloud -> WebAuthn Two-Factor Provider for Nextcloud

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>