### PR TITLE
Fix display of challenge error

### DIFF
--- a/src/components/Challenge.vue
+++ b/src/components/Challenge.vue
@@ -160,9 +160,8 @@ export default {
 				})
 				.then(debug('submitted challengeForm'))
 				.catch(error => {
-					this.error = error
+					this.error = error.toString()
 					logger.error('Challenge failed', { error }) // Example: timeout, interaction refused...
-					window.location = window.location.href.replace('challenge/twofactor_webauthn', 'selectchallenge')
 				})
 		},
 	},


### PR DESCRIPTION
This addresses two things:

1. I removed the immediate redirect after an error occurred. Instead, the user can read the error and press retry manually.

2. The display of the error itself was fixed. Before, the placeholder `{msg}` was not replaced because the message was passed as an object instead of a string.

![Peek 2022-04-29 10-55](https://user-images.githubusercontent.com/1479486/165914232-f527add8-ae59-4e08-a3ef-9469ee71c75b.gif)
