### PR TITLE
Add PHP8.1 + 8.2 lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [7.3, 7.4, 8.0]
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     name: php${{ matrix.php-versions }} lint
     steps:
     - name: Checkout


### PR DESCRIPTION
Ref https://github.com/nextcloud/wg-two-factor-authentication/issues/6.

The PHP8.1 lint should have been there already because the app supports 8.1.