### PR TITLE
Remove click from sign in

### DIFF
--- a/src/components/Challenge.vue
+++ b/src/components/Challenge.vue
@@ -41,13 +41,8 @@
 				{{ t('twofactor_webauthn', 'Retry') }}
 			</Button>
 		</p>
-		<p v-else
-			id="webauthn-info">
-			{{ t('twofactor_webauthn', 'Plug in your security key and press the button below to begin authorization.') }}
-			<Button class="btn sign"
-				@click="sign">
-				{{ t('twofactor_webauthn', 'Use security key') }}
-			</Button>
+		<p v-else id="webauthn-info">
+			{{ t('twofactor_webauthn', 'Use security key') }}
 		</p>
 		<p id="webauthn-error"
 			style="display: none">
@@ -102,6 +97,9 @@ export default {
 		httpWarning() {
 			return document.location.protocol !== 'https:'
 		},
+	},
+	mounted() {
+		this.sign()
 	},
 
 	methods: {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_webauthn/issues/164

Tested with FF and Chrome on Linux. Both allowed me to log in as usual but without the manual click.