### PR TITLE
Drop Nextcloud 21 support

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-stable21 as 21', 'dev-stable22 as 22', 'dev-stable23 as 23', 'dev-stable24 as 24', 'dev-master as 25' ]
+              ocp-version: [ 'dev-stable22 as 22', 'dev-stable23 as 23', 'dev-stable24 as 24', 'dev-master as 25' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout
@@ -20,7 +20,7 @@ jobs:
           - name: Install dependencies
             run: composer i
           - name: Install OCP package
-            if: ${{ contains(matrix.ocp-version, 'dev-stable21') || contains(matrix.ocp-version, 'dev-stable22') || contains(matrix.ocp-version, 'dev-stable23') }}
+            if: ${{ contains(matrix.ocp-version, 'dev-stable22') || contains(matrix.ocp-version, 'dev-stable23') }}
             run: composer require --dev christophwurst/nextcloud:"${{ matrix.ocp-version }}"
           - name: Install OCP package
             if: ${{ contains(matrix.ocp-version, 'dev-stable24') || contains(matrix.ocp-version, 'dev-master') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         nextcloud-version: ['master']
         include:
           - php-version: 8.0
-            nextcloud-version: stable21
+            nextcloud-version: stable22
     name: Nextcloud ${{ matrix.nextcloud-version }} php${{ matrix.php-version }} unit tests
     steps:
     - name: Set up php${{ matrix.php-version }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,11 +16,11 @@
 	<repository>https://github.com/nextcloud/twofactor_webauthn.git</repository>
 
 	<screenshot>https://raw.githubusercontent.com/nextcloud/twofactor_webauthn/main/screenshots/challenge.png</screenshot>
-	
+
 	<dependencies>
 		<php min-version="7.3" max-version="8.1"/>
 		<lib>gmp</lib>
-		<nextcloud min-version="21" max-version="25" />
+		<nextcloud min-version="22" max-version="25" />
 	</dependencies>
 
 	<two-factor-providers>


### PR DESCRIPTION
This will help with https://github.com/nextcloud/twofactor_webauthn/pull/144.