### PR TITLE
Fix white login icon on white background

### DIFF
--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -28,6 +28,6 @@ script('twofactor_webauthn', 'challenge');
 
 ?>
 
-<img class="two-factor-icon" src="<?php print_unescaped(image_path('twofactor_webauthn', 'app.svg')); ?>" alt="">
+<img class="two-factor-icon" src="<?php print_unescaped(image_path('twofactor_webauthn', 'app-dark.svg')); ?>" alt="">
 
 <div id="twofactor-webauthn-challenge"></div>


### PR DESCRIPTION
- [x] Requires dropping Nextcloud 24 and older

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-16 16-09-26](https://user-images.githubusercontent.com/1374172/190660493-834a17bc-05bf-4d31-a7de-0b424453dc0b.png) | ![Bildschirmfoto vom 2022-09-16 16-09-32](https://user-images.githubusercontent.com/1374172/190660540-53888b6a-7c92-472d-8354-d00846c238e0.png) |

cc @nursoda

For https://github.com/nextcloud/twofactor_webauthn/issues/253