### PR TITLE
[stable0.3] Add repair step to migrate old 2FA provider registrations

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,6 +24,12 @@
 		<nextcloud min-version="21" max-version="24" />
 	</dependencies>
 
+	<repair-steps>
+		<post-migration>
+			<step>OCA\TwoFactorWebauthn\Migration\RepairProviderRegistrations</step>
+		</post-migration>
+	</repair-steps>
+
 	<two-factor-providers>
 		<provider>OCA\TwoFactorWebauthn\Provider\WebAuthnProvider</provider>
 	</two-factor-providers>

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 		"psalm": "psalm.phar",
 		"test": "phpunit -c tests/phpunit.xml",
 		"test:acceptance": "phpunit -c tests/phpunit.xml tests/Acceptance",
+		"test:integration": "phpunit -c tests/phpunit.xml tests/Integration",
 		"test:unit": "phpunit -c tests/phpunit.xml tests/Unit",
 		"test:acceptance:dev": "phpunit -c tests/phpunit.xml tests/Acceptance --no-coverage",
 		"test:unit:dev": "phpunit -c tests/phpunit.xml tests/Unit --no-coverage --order-by=defects --stop-on-defect --fail-on-warning --stop-on-error --stop-on-failure",

--- a/lib/Migration/RepairProviderRegistrations.php
+++ b/lib/Migration/RepairProviderRegistrations.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\TwoFactorWebauthn\Migration;
+
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use function sprintf;
+
+/**
+ * Migrate all provider registrations of 'twofactor_webauthn' to just 'webauthn'
+ */
+class RepairProviderRegistrations implements IRepairStep {
+
+	/** @var IDBConnection */
+	private $db;
+
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+	public function getName(): string {
+		return 'Repair provider registrations';
+	}
+
+	public function run(IOutput $output): void {
+		$selectQb = $this->db->getQueryBuilder();
+		$selectQb->select('uid', 'provider_id', 'enabled')
+			->from('twofactor_providers')
+			->where($selectQb->expr()->eq('provider_id', $selectQb->createNamedParameter('twofactor_webauthn')));
+		$updateQb = $this->db->getQueryBuilder();
+		$updateQb->update('twofactor_providers')
+			->set('provider_id', $updateQb->createNamedParameter('webauthn'))
+			->set('enabled', $updateQb->createParameter('enabled'))
+			->where(
+				$updateQb->expr()->eq('provider_id', $updateQb->createNamedParameter('twofactor_webauthn')),
+				$updateQb->expr()->eq('uid', $updateQb->createParameter('uid')),
+			);
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete('twofactor_providers')
+			->where(
+				$deleteQb->expr()->eq('provider_id', $deleteQb->createNamedParameter('twofactor_webauthn')),
+				$deleteQb->expr()->eq('uid', $deleteQb->createParameter('uid')),
+			);
+
+		$result = $selectQb->execute();
+		while ($row = $result->fetch()) {
+			try {
+				$updateQb->setParameter('uid', $row['uid']);
+				$updateQb->setParameter('enabled', $row['enabled'], IQueryBuilder::PARAM_INT);
+				$updateQb->executeStatement();
+			} catch (Exception $e) {
+				if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					// The provider was registered twice for the user. We can safely drop the old one.
+					$deleteQb->setParameter('uid', $row['uid']);
+					$deleteQb->execute();
+				} else {
+					$output->warning(sprintf(
+						$e->getCode() .
+						'Could not migrate %s:%s',
+						$row['provider_id'],
+						$row['uid'],
+					));
+				}
+			}
+		}
+		$result->closeCursor();
+	}
+}

--- a/tests/Integration/Migration/RepairProviderRegistrationsTest.php
+++ b/tests/Integration/Migration/RepairProviderRegistrationsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\TwoFactorWebauthn\Tests\Integration\Migration;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC;
+use OCA\TwoFactorWebauthn\Migration\RepairProviderRegistrations;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+
+class RepairProviderRegistrationsTest extends TestCase {
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var RepairProviderRegistrations */
+	private $repairStep;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = OC::$server->get(IDBConnection::class);
+		$this->repairStep = OC::$server->get(RepairProviderRegistrations::class);
+
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete('twofactor_providers')
+			->where($deleteQb->expr()->eq('uid', $deleteQb->createNamedParameter('test123456789')));
+		$deleteQb->execute();
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete('twofactor_providers')
+			->where($deleteQb->expr()->eq('uid', $deleteQb->createNamedParameter('test123456789')));
+		$deleteQb->execute();
+	}
+
+	public function testFixesOldRegistration(): void {
+		$insertQb = $this->db->getQueryBuilder();
+		$insertQb->insert('twofactor_providers')
+			->values([
+				'uid' => $insertQb->createNamedParameter('test123456789'),
+				'provider_id' => $insertQb->createParameter('provider_id'),
+				'enabled' => $insertQb->createNamedParameter(1),
+			]);
+		$insertQb->setParameter('provider_id', 'twofactor_webauthn');
+		$insertQb->execute();
+		$output = $this->createMock(IOutput::class);
+
+		$this->repairStep->run($output);
+
+		$cntQb = $this->db->getQueryBuilder();
+		$cntQb->select($cntQb->func()->count('*'))
+			->from('twofactor_providers')
+			->where(
+				$cntQb->expr()->eq('uid', $cntQb->createNamedParameter('test123456789')),
+				$cntQb->expr()->eq('provider_id', $cntQb->createNamedParameter('webauthn')),
+			);
+		$result = $cntQb->execute();
+		$cnt = $result->fetchOne();
+		$result->closeCursor();
+		self::assertEquals(1, $cnt);
+	}
+
+	public function testDropsDuplicateRegistration(): void {
+		$insertQb = $this->db->getQueryBuilder();
+		$insertQb->insert('twofactor_providers')
+			->values([
+				'uid' => $insertQb->createNamedParameter('test123456789'),
+				'provider_id' => $insertQb->createParameter('provider_id'),
+				'enabled' => $insertQb->createNamedParameter(1),
+			]);
+		$insertQb->setParameter('provider_id', 'webauthn');
+		$insertQb->execute();
+		$insertQb->setParameter('provider_id', 'twofactor_webauthn');
+		$insertQb->execute();
+		$output = $this->createMock(IOutput::class);
+		$output->expects(self::never())->method('warning');
+
+		$this->repairStep->run($output);
+
+		$cntQb = $this->db->getQueryBuilder();
+		$cntQb->select($cntQb->func()->count('*'))
+			->from('twofactor_providers')
+			->where(
+				$cntQb->expr()->eq('uid', $cntQb->createNamedParameter('test123456789')),
+			);
+		$result = $cntQb->execute();
+		$cnt = $result->fetchOne();
+		$result->closeCursor();
+		self::assertEquals(1, $cnt);
+	}
+}


### PR DESCRIPTION
We switched from the provider id 'twofactor_webauthn' to 'webauthn', therefore Nextcloud has old, outdated registrations of a provider that no longer exists. This patch adds a repair step to bring the old registrations over or delete them if they are duplicated.

Backport of https://github.com/nextcloud/twofactor_webauthn/pull/144