### PR TITLE
ci: Migrate to the new OCP package for static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,6 +20,6 @@ jobs:
           - name: Install dependencies
             run: composer i
           - name: Install OCP package
-            run: composer require --dev christophwurst/nextcloud:"${{ matrix.ocp-version }}" --ignore-platform-req=php
+            run: composer require --dev nextcloud/ocp:"${{ matrix.ocp-version }}" --ignore-platform-req=php
           - name: Run coding standards check
             run: composer run psalm


### PR DESCRIPTION
This unclogs the bump automerge backlog :crossed_fingers: 