### PR TITLE
fix: registration not returning the entityId

### DIFF
--- a/lib/Service/WebAuthnManager.php
+++ b/lib/Service/WebAuthnManager.php
@@ -235,6 +235,7 @@ class WebAuthnManager {
 		$this->eventDispatcher->dispatch(StateChanged::class, new StateChanged($user, true));
 
 		return [
+			'entityId' => $entity->getId(),
 			'id' => base64_encode($publicKeyCredentialSource->getPublicKeyCredentialId()),
 			'name' => $name,
 			'createdAt' => $entity !== null ? $entity->getCreatedAt() : null,


### PR DESCRIPTION
Fix https://github.com/nextcloud/twofactor_webauthn/issues/497