### PR TITLE
fix: prefer user verification

### DIFF
--- a/lib/Service/WebAuthnManager.php
+++ b/lib/Service/WebAuthnManager.php
@@ -131,7 +131,7 @@ class WebAuthnManager {
 
 		$authenticatorSelectionCriteria = new AuthenticatorSelectionCriteria(
 			AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE,
-			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_DISCOURAGED,
+			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
 			AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_NO_PREFERENCE,
 			false,
 		);
@@ -281,14 +281,13 @@ class WebAuthnManager {
 			random_bytes(32),                                                    // Challenge
 			null,                                                                  // Relying Party ID
 			[],                                  // Registered PublicKeyCredentialDescriptor classes
-			null, // User verification requirement
+			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED, // User verification requirement
 			60000,                                                              // Timeout
 			$extensions
 		);
 		$publicKeyCredentialRequestOptions
 			->setRpId($this->stripPort($serverHost))
-			->allowCredentials(...$registeredPublicKeyCredentialDescriptors)
-			->setUserVerification(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_DISCOURAGED);
+			->allowCredentials(...$registeredPublicKeyCredentialDescriptors);
 
 		$this->session->set(self::TWOFACTORAUTH_WEBAUTHN_REQUEST, $publicKeyCredentialRequestOptions->jsonSerialize());
 


### PR DESCRIPTION
Gracefully handle keys that enforce user verification. A preferred user verification effectively lets the key decide whether to request it or not without enforcing it.