### PR TITLE
chore(composer): require psr/log:^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 		"php": ">=8.1.0",
 		"ext-json": "*",
 		"bamarni/composer-bin-plugin": "^1.8.2",
+		"psr/log": "^1",
 		"web-auth/webauthn-lib": "^4.9.1"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3062a3a7d35b00391937f1cf98b697e7",
+    "content-hash": "3b6416daafda577f8f1c6dca9d051484",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -514,30 +514,30 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.0"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "src"
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -558,9 +558,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "spomky-labs/cbor-php",


### PR DESCRIPTION
It pulls in `psr/log:^3` without any constraints which breaks (testing) other apps as the broader ecosystem is still on `^1`.

`
PHP Fatal error:  Declaration of Psr\Log\Test\TestLogger::log($level, $message, array $context = []) must be compatible with Psr\Log\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /home/richard/src/nextcloud/master/dev_apps/mail/vendor/psr/log/Psr/Log/Test/TestLogger.php on line 69
Script phpunit -c tests/phpunit.unit.xml --fail-on-warning handling the test:unit event returned with error code 255
`