### PR TITLE
chore: Removed unused deprecated `ILogger`

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -29,30 +29,19 @@ namespace OCA\TwoFactorWebauthn\Activity;
 use InvalidArgumentException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IProvider;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory as L10nFactory;
 
 class Provider implements IProvider {
 
-	/** @var L10nFactory */
-	private $l10n;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var ILogger */
-	private $logger;
-
 	/**
 	 * @param L10nFactory $l10n
 	 * @param IURLGenerator $urlGenerator
-	 * @param ILogger $logger
 	 */
-	public function __construct(L10nFactory $l10n, IURLGenerator $urlGenerator, ILogger $logger) {
-		$this->logger = $logger;
-		$this->urlGenerator = $urlGenerator;
-		$this->l10n = $l10n;
+	public function __construct(
+		private L10nFactory $l10n,
+		private IURLGenerator $urlGenerator,
+	) {
 	}
 
 	/**

--- a/tests/Unit/Activity/ProviderTest.php
+++ b/tests/Unit/Activity/ProviderTest.php
@@ -31,14 +31,13 @@ use InvalidArgumentException;
 use OCA\TwoFactorWebauthn\Activity\Provider;
 use OCP\Activity\IEvent;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ProviderTest extends TestCase {
-	private $l10n;
-	private $urlGenerator;
-	private $logger;
+	private IFactory&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
 
 	/** @var Provider */
 	private $provider;
@@ -48,9 +47,8 @@ class ProviderTest extends TestCase {
 
 		$this->l10n = $this->createMock(IFactory::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->logger = $this->createMock(ILogger::class);
 
-		$this->provider = new Provider($this->l10n, $this->urlGenerator, $this->logger);
+		$this->provider = new Provider($this->l10n, $this->urlGenerator);
 	}
 
 	public function testParseUnrelated(): void {


### PR DESCRIPTION
If we need a logger in the future we simply can use the PSR-3 `LoggerInterface`. But currently it is unused, so we do not need to dependency inject it.