### PR TITLE
feat!: migrate Template return types to ITemplate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.1', '8.2', '8.3', '8.4']
-        nextcloud-version: ['master', 'stable31', 'stable30']
-        exclude:
-          - php-version: '8.4'
-            nextcloud-version: 'stable30'
+        nextcloud-version: ['master']
     name: Nextcloud ${{ matrix.nextcloud-version }} php${{ matrix.php-version }} unit tests
     steps:
     - name: Set up Nextcloud env
@@ -51,14 +48,11 @@ jobs:
           - php-version: '8.1'
             nextcloud-version: master
             db: 'oci'
-          - php-version: '8.1'
+          - php-version: '8.2'
             nextcloud-version: master
             db: 'pgsql'
           - php-version: '8.3'
-            nextcloud-version: stable31
-            db: 'mysql'
-          - php-version: '8.2'
-            nextcloud-version: stable30
+            nextcloud-version: master
             db: 'mysql'
     name: Nextcloud ${{ matrix.nextcloud-version }} php${{ matrix.php-version }}-${{ matrix.db }} integration tests
     services:
@@ -152,11 +146,8 @@ jobs:
     strategy:
       matrix:
         php-version: [ '8.1', '8.2', '8.3', '8.4' ]
-        nextcloud-version: [ 'master', 'stable31', 'stable30' ]
+        nextcloud-version: [ 'master' ]
         node-version: [ '20' ]
-        exclude:
-          - php-version: '8.4'
-            nextcloud-version: 'stable30'
     steps:
       - name: Set up Nextcloud env
         uses: ChristophWurst/setup-nextcloud@fc0790385c175d97e88a7cb0933490de6e990374 # v0.3.2

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>Two-Factor WebAuthn</name>
 	<summary>WebAuthn two-factor provider</summary>
 	<description>A two-factor provider for WebAuthn devices</description>
-	<version>2.2.0-dev.0</version>
+	<version>3.0.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Michael Blumenstein</author>
@@ -25,7 +25,7 @@
 	<dependencies>
 		<php min-version="8.1" max-version="8.4"/>
 		<lib>gmp</lib>
-		<nextcloud min-version="30" max-version="32" />
+		<nextcloud min-version="32" max-version="32" />
 	</dependencies>
 
 	<repair-steps>

--- a/lib/Provider/WebAuthnLoginProvider.php
+++ b/lib/Provider/WebAuthnLoginProvider.php
@@ -12,13 +12,10 @@ namespace OCA\TwoFactorWebauthn\Provider;
 use OCA\TwoFactorWebauthn\AppInfo\Application;
 use OCP\Authentication\TwoFactorAuth\ILoginSetupProvider;
 use OCP\Template;
+use OCP\Template\ITemplate;
 
 class WebAuthnLoginProvider implements ILoginSetupProvider {
-
-	/**
-	 * @return Template
-	 */
-	public function getBody(): Template {
+	public function getBody(): ITemplate {
 		return new Template(Application::APP_ID, 'login-setup');
 	}
 }

--- a/lib/Provider/WebAuthnProvider.php
+++ b/lib/Provider/WebAuthnProvider.php
@@ -25,6 +25,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Template;
+use OCP\Template\ITemplate;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -87,7 +88,7 @@ class WebAuthnProvider implements IProvider, IProvidesIcons, IProvidesPersonalSe
 	/**
 	 * Get the template for rending the 2FA provider view
 	 */
-	public function getTemplate(IUser $user): Template {
+	public function getTemplate(IUser $user): ITemplate {
 		$publicKey = $this->manager->startAuthenticate($user, $this->request->getServerHost());
 		$this->initialState->provideInitialState('credential-request-options', $publicKey);
 		return new Template('twofactor_webauthn', 'challenge');

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -11,9 +11,10 @@ namespace OCA\TwoFactorWebauthn\Settings;
 
 use OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings;
 use OCP\Template;
+use OCP\Template\ITemplate;
 
 class Personal implements IPersonalProviderSettings {
-	public function getBody(): Template {
+	public function getBody(): ITemplate {
 		return new Template('twofactor_webauthn', 'personal');
 	}
 }


### PR DESCRIPTION
Requires a major bump as we need to drop compatibility with Nextcloud < 32. The providers are registered via `info.xml` so we can't implement dynamic register logic via `interface_exists()`.

Fixes CI

Ref https://github.com/nextcloud/server/pull/51029