### PR TITLE
fix: activating and deactivating devices

### DIFF
--- a/src/components/Device.vue
+++ b/src/components/Device.vue
@@ -14,7 +14,9 @@
 				</template>
 				{{ createdAtFormatted }}
 			</ActionText>
-			<ActionCheckbox :checked="active" @update:checked="changeActivation">
+			<ActionCheckbox data-testid="device-active"
+				:model-value="active"
+				@update:modelValue="changeActivation">
 				{{ t('twofactor_webauthn', 'Active') }}
 			</ActionCheckbox>
 			<ActionButton icon="icon-delete" :close-after-click="true" @click="onDelete">

--- a/src/tests/e2e/settings.spec.js
+++ b/src/tests/e2e/settings.spec.js
@@ -66,3 +66,82 @@ test('add device and remove it again', async ({ page }) => {
 	// Device should be removed from the list
 	await expect(page.locator('#two-factor-auth')).not.toContainText(keyName)
 })
+
+test('add device and disable it', async ({ page }) => {
+	const keyName = randomHex()
+
+	await page.goto('./index.php/settings/user/security')
+	await page.getByLabel('Settings menu').click()
+	await page.getByRole('link', { name: 'Personal settings' }).click()
+	await page.getByLabel('Personal').getByRole('link', { name: 'Security' }).click()
+
+	// Add a new device
+	await page.getByRole('button', { name: 'Add security key' }).click()
+	await page.getByPlaceholder('Name your security key').fill(keyName)
+	await page.getByRole('button', { name: 'Add', exact: true }).click()
+
+	// Device should be added to the list
+	await expect(page.locator('#two-factor-auth')).toContainText(keyName)
+
+	// Device should be active by default
+	await page.locator(`:text-matches("${keyName}") button[aria-label="Actions"]`).click()
+	await expect(page.getByLabel('Active')).toBeChecked()
+
+	// Deactivate device
+	await page.getByText('Active').click()
+	await expect(page.getByLabel('Active')).not.toBeChecked()
+
+	// State should be persisted when closing and opening the menu again
+	await page.locator(`:text-matches("${keyName}") button[aria-label="Actions"]`).click()
+	await expect(page.getByLabel('Active')).not.toBeVisible()
+	await page.locator(`:text-matches("${keyName}") button[aria-label="Actions"]`).click()
+
+	// Activate device again
+	await expect(page.getByLabel('Active')).not.toBeChecked()
+	await page.getByText('Active').click()
+	await expect(page.getByLabel('Active')).toBeChecked()
+})
+
+test('show hint when all devices are disabled', async ({ page }) => {
+	const keyName = randomHex()
+
+	await page.goto('./index.php/settings/user/security')
+	await page.getByLabel('Settings menu').click()
+	await page.getByRole('link', { name: 'Personal settings' }).click()
+	await page.getByLabel('Personal').getByRole('link', { name: 'Security' }).click()
+
+	// Add a new device
+	await page.getByRole('button', { name: 'Add security key' }).click()
+	await page.getByPlaceholder('Name your security key').fill(keyName)
+	await page.getByRole('button', { name: 'Add', exact: true }).click()
+
+	// Device should be added to the list
+	await expect(page.locator('#two-factor-auth')).toContainText(keyName)
+
+	// Hint should not be visible as a new device was just added
+	await expect(page.locator('#twofactor-webauthn-settings')).not.toContainText('All security keys are deactivated.')
+
+	// Disable all devices
+	const devices = await page.locator('.webauthn-device').allTextContents()
+	expect(devices.length).toBeGreaterThan(0)
+	for (const device of devices) {
+		const toggleMenu = () => page.locator(`:text-matches("${device.trim()}") button[aria-label="Actions"]`).click()
+		const hideMenu = async () => {
+			await toggleMenu()
+			await expect(page.getByTestId('device-active')).not.toBeVisible()
+		}
+
+		await toggleMenu()
+		if (!await page.getByLabel('Active').isChecked()) {
+			await hideMenu()
+			continue
+		}
+
+		await page.getByText('Active').click()
+		await expect(page.getByLabel('Active')).not.toBeChecked()
+		await hideMenu()
+	}
+
+	// Hint should be visible
+	await expect(page.locator('#twofactor-webauthn-settings')).toContainText('All security keys are deactivated.')
+})


### PR DESCRIPTION
Regression from #763 

I added an E2E test for the activation checkbox.