### PR TITLE
[stable2.2] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8964,24 +8964,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -15654,9 +15636,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.1.0.tgz",
-      "integrity": "sha512-aQpaN81X6tXie1FoOB7xlMfCsN19pSvRAeYUHOdFWOlhpQ/LlbfTqYwwmEDFV0h8GGuqmCmKmT+pxcUV/Nt2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -15664,6 +15646,7 @@
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
         "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
         "@types/sockjs": "^0.3.36",
@@ -15674,10 +15657,9 @@
         "colorette": "^2.0.10",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "graceful-fs": "^4.2.6",
-        "html-entities": "^2.4.0",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",
@@ -15710,6 +15692,20 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/webpack-dev-server/node_modules/ajv": {
@@ -22563,13 +22559,6 @@
         "whatwg-encoding": "^2.0.0"
       }
     },
-    "html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
-      "dev": true,
-      "peer": true
-    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -27123,15 +27112,16 @@
       }
     },
     "webpack-dev-server": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.1.0.tgz",
-      "integrity": "sha512-aQpaN81X6tXie1FoOB7xlMfCsN19pSvRAeYUHOdFWOlhpQ/LlbfTqYwwmEDFV0h8GGuqmCmKmT+pxcUV/Nt2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
         "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
         "@types/sockjs": "^0.3.36",
@@ -27142,10 +27132,9 @@
         "colorette": "^2.0.10",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "graceful-fs": "^4.2.6",
-        "html-entities": "^2.4.0",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",
@@ -27159,6 +27148,19 @@
         "ws": "^8.18.0"
       },
       "dependencies": {
+        "@types/express-serve-static-core": {
+          "version": "4.19.6",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+          "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*",
+            "@types/send": "*"
+          }
+        },
         "ajv": {
           "version": "8.17.1",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 1 vulnerabilities found in your project.

## Updated dependencies
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser
* Severity: **moderate** (CVSS 6.5)
* Reference: [https://github.com/advisories/GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h)
* Affected versions: <=5.2.0
* Package usage:
  * `node_modules/webpack-dev-server`