### PR TITLE
ci(test): run apt-update before installing stunnel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
         working-directory: nextcloud/apps/twofactor_webauthn
         run: npm run dev
       - name: Install stunnel (tiny https proxy)
-        run: sudo apt-get install -y stunnel
+        run: sudo apt-get update && sudo apt-get install -y stunnel
       - name: Start php server and https proxy
         working-directory: nextcloud
         run: |


### PR DESCRIPTION
CI might fail if it tries to install old/outdated packages.