### PR TITLE
ci(test): thin out E2E matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,11 +177,15 @@ jobs:
     needs: node-version
     strategy:
       matrix:
-        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
-        nextcloud-version: [ 'master', 'stable32', 'stable31']
+        php-version: [ '8.1', '8.2', '8.4', '8.5' ]
+        nextcloud-version: [ 'master']
         include:
           - php-version: '8.5'
-            nextcloud-version: 'master'
+            nextcloud-version: 'stable33'
+          - php-version: '8.3'
+            nextcloud-version: 'stable32'
+          - php-version: '8.1'
+            nextcloud-version: 'stable31'
         exclude:
           - php-version: '8.1'
             nextcloud-version: 'master'


### PR DESCRIPTION
From 12 jobs to 7 jobs, and I don't think we lose a lot. This still covers all PHP versions and all server branches at least once.