### PR TITLE
Refactor startRegister to use UID instead of displayName

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -35,8 +35,15 @@ class SettingsController extends ALoginSetupController {
 	 * @UseSession
 	 */
 	public function startRegister(): JSONResponse {
-		return new JSONResponse($this->manager->startRegistration($this->userSession->getUser(), $this->request->getServerHost()));
+		$user = $this->userSession->getUser();
+		$options = $this->manager->startRegistration($user, $this->request->getServerHost());
+		$data = json_decode(json_encode($options), true);
+		if (isset($data['user']['displayName'])) {
+			$data['user']['displayName'] = $user->getUID();
+		}
+		return new JSONResponse($data);
 	}
+	
 
 	/**
 	 * @NoAdminRequired


### PR DESCRIPTION
Refactoring startRegister function to replace displayName with UID to overcome the error when displayName contains non-ASCII symbols.

Solves https://github.com/nextcloud/twofactor_webauthn/issues/945