### PR TITLE
Fix DataCloneError when credentialRequestOptions is relayed by password-manager extensions

### DIFF
--- a/src/components/Challenge.vue
+++ b/src/components/Challenge.vue
@@ -94,7 +94,7 @@ export default {
 			let authResponse
 			try {
 				authResponse = await startAuthentication({
-					optionsJSON: this.credentialRequestOptions,
+					optionsJSON: JSON.parse(JSON.stringify(this.credentialRequestOptions)),
 				})
 			} catch (error) {
 				switch (error.name) {


### PR DESCRIPTION
Fixes #995

`credentialRequestOptions` comes from the Pinia store, so nested values (e.g. `allowCredentials[i].transports`) are still Vue-reactive `Proxy` objects when passed to `startAuthentication()`. The native `navigator.credentials.get()` handles that fine via WebIDL conversion, but password-manager extensions that intercept the call and relay it via `window.postMessage()` (structured clone) choke on the Proxies with `DataCloneError: ... could not be cloned.` — confirmed with both Bitwarden and Enpass.

This unwraps the options into a plain, serializable object before handing them to `startAuthentication()`. `JSON.parse(JSON.stringify(...))` is used instead of `structuredClone()` because `structuredClone()` fails on reactive Proxies for the same reason. The options are pure JSON (base64url strings), so the round-trip is lossless.

Root cause analysis and manual verification by @tschuegy and @Rumbelstilzchen in #995.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
